### PR TITLE
Docs/#19 rename to instance segmentation

### DIFF
--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -10,7 +10,7 @@ order: 2
 ## Examples
 {:.no_toc}
 
-To solve the task of cone detection, we provide manually annotated bounding boxes and segmentation masks.
+To solve the task of cone detection, we provide manually annotated bounding boxes and instance segmentation masks.
 Both annotation types consist of the same semantic classes and additional tags (see [overview]({{ "/overview/" | relative_url }})).
 A small sample dataset can be downloaded at the bottom of this page helping you to understand our data structure.
 
@@ -28,7 +28,7 @@ Each color represents a different cone type.
 
 ### Segmentation
 
-We further provide pixel-based semantic masks for a smaller subset of our images.
+We further provide pixel-based object masks for a smaller subset of our images.
 Note that each cone is labeled individually and, thus, allows for both class and instance segmentation.
 In the case of overlapping cones, the mask of the partially covered cone might consist of multiple patches belonging to the same label.  
 

--- a/docs/pages/how_to_contribute.md
+++ b/docs/pages/how_to_contribute.md
@@ -68,7 +68,7 @@ They are based on the experience with the first version of FSOCO.
 > If you do not have a cone detector yet, just start training as soon as you have a basic set and then continuously re-train it while extending your dataset.
 > <br>
 > For segmentation labels, Supervisely's smart labeling tool works very well for nearby cones.
-> For cones that are farther away, it is typically faster to first draw the boundary and the fill it.
+> For cones that are farther away, it is typically faster to first draw the boundary and then fill it.
 
 ### Step-by-step Manual
 

--- a/docs/pages/overview.md
+++ b/docs/pages/overview.md
@@ -11,7 +11,7 @@ order: 1
 {:.no_toc}
 
 The FSOCO dataset consists of manually annotated images that have been submitted by the Formula Student Driverless community.
-We provide ground truth data for cone detection and support both bounding boxes and semantic segmentation.
+We provide ground truth data for cone detection and support both bounding boxes and instance segmentation.
 On this page we give an overview of the dataset's features, its content, and our labeling policy.
 
 * TOC
@@ -24,7 +24,7 @@ On this page we give an overview of the dataset's features, its content, and our
 
 **Type of annotations**
 - Bounding boxes
-- Semantic segmentation
+- Instance segmentation
 
 **Volume**
 - 2053 annotated images with bounding boxes (on average 16.1 boxes per image)

--- a/docs/pages/overview.md
+++ b/docs/pages/overview.md
@@ -22,7 +22,7 @@ On this page we give an overview of the dataset's features, its content, and our
 
 <img src="../assets/img/overview/merged_image.png" style="width: 60%;  height: auto; float:right;">
 
-**Type of annotations**
+**Types of annotations**
 - Bounding boxes
 - Instance segmentation
 

--- a/docs/pages/tools.md
+++ b/docs/pages/tools.md
@@ -15,7 +15,7 @@ It is a small, extensible tool for data manipulation and analysis that is based 
 For installation, please refer to the [README](https://github.com/fsoco/fsoco-dataset/blob/master/tools/README.md).
 
 We welcome contributions and would be thrilled to review and, hopefully, accept your contribution as well.
-If you are interested, please refer to [CONTRIBUTING](https://github.com/fsoco/fsoco-dataset/blob/master/tools/CONTRIBUTING.md).
+If you are interested, please refer to [CONTRIBUTING](https://github.com/fsoco/fsoco-dataset/blob/master/CONTRIBUTING.md).
 <br/>
 A good way to find inspiration is by looking for "Help Wanted" Issues.
 


### PR DESCRIPTION
Fix a typo, a broken link, and clarify that we provide instance masks opposed to semantic segmentation masks.