### PR TITLE
Add resolved tag to indicated manually reviewed label issues

### DIFF
--- a/tools/sanity_checker/bounding_box_checker.py
+++ b/tools/sanity_checker/bounding_box_checker.py
@@ -11,6 +11,9 @@ class BoundingBoxChecker(LabelChecker):
             raise ValueError(
                 f"Wrong label type: {label['geometryType']}. Expected: rectangle."
             )
+        # Do not run the checker on labels tagged as "resolved"
+        if LabelChecker._is_resolved_tagged(label):
+            return True
         # Run all checks on the same label.
         self.label = label
 

--- a/tools/sanity_checker/label_checker.py
+++ b/tools/sanity_checker/label_checker.py
@@ -24,6 +24,9 @@ class LabelChecker(ABC):
     issue_tag_meta = sly.TagMeta(
         name="issue", value_type=sly.TagValueType.ANY_STRING, color=[255, 0, 0]
     )
+    resolved_tag_meta = sly.TagMeta(
+        name="resolved", value_type=sly.TagValueType.NONE, color=[0, 255, 0]
+    )
 
     def __init__(
         self,
@@ -132,5 +135,12 @@ class LabelChecker(ABC):
                 tag["name"] == LabelChecker.issue_tag_meta.name
                 and tag["value"] == tag_text
             ):
+                return True
+        return False
+
+    @staticmethod
+    def _is_resolved_tagged(label: dict):
+        for tag in label["tags"]:
+            if tag["name"] == LabelChecker.resolved_tag_meta.name:
                 return True
         return False

--- a/tools/sanity_checker/sanity_checker.py
+++ b/tools/sanity_checker/sanity_checker.py
@@ -138,13 +138,24 @@ class SanityChecker:
                 project_meta_json
             )
 
-            # Add "Issue" tag if it does not exist yet
+            update_project_meta = False
+            # Add "issue" tag if it does not exist yet
             if LabelChecker.issue_tag_meta.name not in [
                 tag["name"] for tag in project_meta_json["tags"]
             ]:
                 self.sly_project_metas[sly_project.name] = self.sly_project_metas[
                     sly_project.name
                 ].add_tag_meta(LabelChecker.issue_tag_meta)
+                update_project_meta = True
+            # Add "resolved" tag if it does not exist yet
+            if LabelChecker.resolved_tag_meta.name not in [
+                tag["name"] for tag in project_meta_json["tags"]
+            ]:
+                self.sly_project_metas[sly_project.name] = self.sly_project_metas[
+                    sly_project.name
+                ].add_tag_meta(LabelChecker.resolved_tag_meta)
+                update_project_meta = True
+            if update_project_meta:
                 safe_request(
                     self.sly_api.project.update_meta,
                     sly_project.id,

--- a/tools/sanity_checker/segmentation_checker.py
+++ b/tools/sanity_checker/segmentation_checker.py
@@ -18,6 +18,9 @@ class SegmentationChecker(LabelChecker):
             raise ValueError(
                 f"Wrong label type: {label['geometryType']}. Expected: bitmap."
             )
+        # Do not run the checker on labels tagged as "resolved"
+        if LabelChecker._is_resolved_tagged(label):
+            return True
         # Run all checks on the same label.
         self.label = label
 


### PR DESCRIPTION
Some edge cases of the sanity checks require a human reviewer to decided whether the label can be kept. Without the resolved tag, the sanity checker would tag those labels every time in every run although it already had been reviewed.