### PR TITLE
Add test skip via project description

### DIFF
--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -6,7 +6,7 @@ from requests_html import HTMLSession
 from typing import List
 
 GAPPS_URL = "https://script.google.com/macros/s/AKfycbwe9WgdWy_nsfyk1zC13pGc-ZnoJ4iRGvvJyIXZ2h4buI5MWLTL/exec"
-
+SKIP_DESC_FLAG = "skip_test"
 
 def get_teams() -> List[str]:
     s = os.environ.get("SANITY_CHECKS_TEAMS")
@@ -40,14 +40,14 @@ def get_teams() -> List[str]:
             project["name"]
             for project in r_projects.json()["entities"]
             if project["name"] not in env_teams
-            and "skipt_test" not in project["description"]
+            and SKIP_DESC_FLAG not in project["description"]
         ]
     else:
         teams = [
             project["name"]
             for project in r_projects.json()["entities"]
             if project["name"] in env_teams
-            and "skip_test" not in project["description"]
+            and SKIP_DESC_FLAG not in project["description"]
         ]
     logging.info(teams)
     return teams

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -47,6 +47,7 @@ def get_teams() -> List[str]:
             project["name"]
             for project in r_projects.json()["entities"]
             if project["name"] in env_teams
+            and "skip_test" not in project["description"]
         ]
     logging.info(teams)
     teams = [team for team in teams if team not in IGNORE]

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -6,7 +6,6 @@ from requests_html import HTMLSession
 from typing import List
 
 GAPPS_URL = "https://script.google.com/macros/s/AKfycbwe9WgdWy_nsfyk1zC13pGc-ZnoJ4iRGvvJyIXZ2h4buI5MWLTL/exec"
-IGNORE = ["BME watermarked", "Donations"]
 
 
 def get_teams() -> List[str]:
@@ -41,6 +40,7 @@ def get_teams() -> List[str]:
             project["name"]
             for project in r_projects.json()["entities"]
             if project["name"] not in env_teams
+            and "skipt_test" not in project["description"]
         ]
     else:
         teams = [
@@ -50,7 +50,6 @@ def get_teams() -> List[str]:
             and "skip_test" not in project["description"]
         ]
     logging.info(teams)
-    teams = [team for team in teams if team not in IGNORE]
     return teams
 
 

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -6,7 +6,7 @@ from requests_html import HTMLSession
 from typing import List
 
 GAPPS_URL = "https://script.google.com/macros/s/AKfycbwe9WgdWy_nsfyk1zC13pGc-ZnoJ4iRGvvJyIXZ2h4buI5MWLTL/exec"
-SKIP_DESC_FLAG = "skip_test"
+SKIP_DESC_FLAG = "skip_status_page_test"
 
 def get_teams() -> List[str]:
     s = os.environ.get("SANITY_CHECKS_TEAMS")


### PR DESCRIPTION
Adding `skip_test` to a Sly project's description allows us to skip it for our contribution status page test.