### PR TITLE
Fix Website Checks CI

### DIFF
--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -60,7 +60,7 @@ def test_google_app_script_response():
     for team in teams:
         logging.info(f"Getting page for {team}")
         r = session.get(GAPPS_URL, params={"team_name": team})
-        status = True if r.find(team) >= 0 else False
+        status = True if r.text.find(team) >= 0 else False
         response_status.append(status)
     assert all(response_status), [
         team_name for team_name, res in zip(teams, response_status) if not res

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -56,18 +56,12 @@ def get_teams() -> List[str]:
 def test_google_app_script_response():
     session = HTMLSession()
     teams = get_teams()
-    responses = []
+    response_status = []
     for team in teams:
         logging.info(f"Getting page for {team}")
         r = session.get(GAPPS_URL, params={"team_name": team})
-        r.html.render(sleep=4, timeout=15.0)
-        responses.append(r.html.text)
-    # render for some reason doesn't execute the GApp JS script correctly
-    # The User HTML generated can be searched through regex though
-    # "Success" => team_name found; "Fail" => team_name not found
-    response_status = [
-        True if response.find("Success") >= 0 else False for response in responses
-    ]
+        status = True if r.find(team) >= 0 else False
+        response_status.append(status)
     assert all(response_status), [
         team_name for team_name, res in zip(teams, response_status) if not res
     ]

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -5,7 +5,7 @@ import requests
 from requests_html import HTMLSession
 from typing import List
 
-GAPPS_URL = "https://script.google.com/macros/s/AKfycbwe9WgdWy_nsfyk1zC13pGc-ZnoJ4iRGvvJyIXZ2h4buI5MWLTL/exec"
+GAPPS_URL = "https://script.google.com/macros/s/AKfycbzxi0VKZJPCpySqvnxiGLsfBYOiHuxKo2Wtg4dONoxI_Huw-YkjqJVmBGCfGS7CfhPJ/exec"
 SKIP_DESC_FLAG = "skip_status_page_test"
 
 def get_teams() -> List[str]:

--- a/docs/_tests/test_contribution_procedure_status_page.py
+++ b/docs/_tests/test_contribution_procedure_status_page.py
@@ -59,7 +59,7 @@ def test_google_app_script_response():
     response_status = []
     for team in teams:
         logging.info(f"Getting page for {team}")
-        r = session.get(GAPPS_URL, params={"team_name": team})
+        r = session.get(GAPPS_URL, params={"team_name": team, "what": "get_job_status"})
         status = True if r.text.find(team) >= 0 else False
         response_status.append(status)
     assert all(response_status), [


### PR DESCRIPTION
Closes #238, see description there.

## Before
- Broken website checks in CI
- Complicated logic in Google App Script for CI tests

## After
- [x] Simplified Google App Script logic
- [x] Unnecessary `render` removed from test
- [x] Working CI, see [passing manual workflow](https://github.com/fsoco/fsoco-dataset/actions/runs/2143689648)