### PR TITLE
Support segmentation for sly2yolo

### DIFF
--- a/tools/label_converters/class_id_to_fsoco.yaml
+++ b/tools/label_converters/class_id_to_fsoco.yaml
@@ -1,4 +1,12 @@
 # Classes: use ints
+yellow_cone: 0
+blue_cone: 1
+orange_cone: 2
+large_orange_cone: 3
+unknown_cone:
+  - 4
+  - 5
+
 seg_yellow_cone: 0
 seg_blue_cone: 1
 seg_orange_cone: 2

--- a/tools/label_converters/class_id_to_fsoco.yaml
+++ b/tools/label_converters/class_id_to_fsoco.yaml
@@ -1,8 +1,8 @@
 # Classes: use ints
-yellow_cone: 0
-blue_cone: 1
-orange_cone: 2
-large_orange_cone: 3
-unknown_cone:
+seg_yellow_cone: 0
+seg_blue_cone: 1
+seg_orange_cone: 2
+seg_large_orange_cone: 3
+seg_unknown_cone:
   - 4
   - 5

--- a/tools/label_converters/sly2yolo/click_sly2yolo.py
+++ b/tools/label_converters/sly2yolo/click_sly2yolo.py
@@ -7,8 +7,9 @@ from .sly2yolo import main
 @click.argument("sly_project_folder", type=str)
 @click.argument("output_folder", type=str)
 @click.option("--remove_watermark", is_flag=True, default=False)
+@click.option("--segmentation", "-s", is_flag=True, default=False)
 @click.option("--exclude", "-e", multiple=True)
-def sly2yolo(sly_project_folder, output_folder, remove_watermark, exclude):
+def sly2yolo(sly_project_folder, output_folder, remove_watermark, segmentation, exclude):
     """
     Supervisely  => Darknet YOLO format
 
@@ -51,7 +52,7 @@ def sly2yolo(sly_project_folder, output_folder, remove_watermark, exclude):
 
     """
     click.echo("[LOG] Running Supervisely to  Darknet Yolo label converter")
-    main(sly_project_folder, output_folder, remove_watermark, exclude)
+    main(sly_project_folder, output_folder, remove_watermark, segmentation, exclude)
 
 
 if __name__ == "__main__":

--- a/tools/label_converters/sly2yolo/click_sly2yolo.py
+++ b/tools/label_converters/sly2yolo/click_sly2yolo.py
@@ -9,7 +9,9 @@ from .sly2yolo import main
 @click.option("--remove_watermark", is_flag=True, default=False)
 @click.option("--segmentation", "-s", is_flag=True, default=False)
 @click.option("--exclude", "-e", multiple=True)
-def sly2yolo(sly_project_folder, output_folder, remove_watermark, segmentation, exclude):
+def sly2yolo(
+    sly_project_folder, output_folder, remove_watermark, segmentation, exclude
+):
     """
     Supervisely  => Darknet YOLO format
 

--- a/tools/label_converters/sly2yolo/sly2yolo.py
+++ b/tools/label_converters/sly2yolo/sly2yolo.py
@@ -24,10 +24,10 @@ def clean_export_dir(darknet_export_images_dir: Path, darknet_export_labels_dir:
 
 
 def export_image(
-        darknet_export_images_dir: Path,
-        src_file: Path,
-        new_file_name: str,
-        remove_watermark: bool,
+    darknet_export_images_dir: Path,
+    src_file: Path,
+    new_file_name: str,
+    remove_watermark: bool,
 ):
     if remove_watermark:
         rescale_copy_image(darknet_export_images_dir, src_file, new_file_name)
@@ -45,26 +45,26 @@ def copy_image(darknet_export_images_dir: Path, src_file: Path, new_file_name: s
 
 
 def rescale_copy_image(
-        darknet_export_images_dir: Path, src_file: Path, new_file_name: str
+    darknet_export_images_dir: Path, src_file: Path, new_file_name: str
 ):
     image = cv.imread(str(src_file))
     cropped_image = image[
-                    FSOCO_IMPORT_BORDER_THICKNESS:-FSOCO_IMPORT_BORDER_THICKNESS,
-                    FSOCO_IMPORT_BORDER_THICKNESS:-FSOCO_IMPORT_BORDER_THICKNESS,
-                    :,
-                    ]
+        FSOCO_IMPORT_BORDER_THICKNESS:-FSOCO_IMPORT_BORDER_THICKNESS,
+        FSOCO_IMPORT_BORDER_THICKNESS:-FSOCO_IMPORT_BORDER_THICKNESS,
+        :,
+    ]
 
     new_dst_file_name = darknet_export_images_dir / new_file_name
     cv.imwrite(str(new_dst_file_name), cropped_image)
 
 
 def convert_object_entry(
-        obj: dict,
-        image_width: float,
-        image_height: float,
-        class_id_mapping: dict,
-        remove_watermark: bool,
-        exclude_tags: list,
+    obj: dict,
+    image_width: float,
+    image_height: float,
+    class_id_mapping: dict,
+    remove_watermark: bool,
+    exclude_tags: list,
 ):
     tags = [tag["name"] for tag in obj["tags"]]
 
@@ -99,10 +99,10 @@ def convert_object_entry(
     norm_bb_height = bb_height / image_height
 
     if not (
-            (0 <= norm_x <= 1)
-            or (0 <= norm_y <= 1)
-            or (0 <= norm_bb_width <= 1)
-            or (0 <= norm_bb_height <= 1)
+        (0 <= norm_x <= 1)
+        or (0 <= norm_y <= 1)
+        or (0 <= norm_bb_width <= 1)
+        or (0 <= norm_bb_height <= 1)
     ):
         raise RuntimeWarning(
             f"Normalized bounding box values outside the valid range! "
@@ -113,12 +113,12 @@ def convert_object_entry(
 
 
 def convert_object_entry_segmentation(
-        obj: dict,
-        image_width: float,
-        image_height: float,
-        class_id_mapping: dict,
-        remove_watermark: bool,
-        exclude_tags: list,
+    obj: dict,
+    image_width: float,
+    image_height: float,
+    class_id_mapping: dict,
+    remove_watermark: bool,
+    exclude_tags: list,
 ):
     tags = [tag["name"] for tag in obj["tags"]]
 
@@ -132,7 +132,9 @@ def convert_object_entry_segmentation(
     n = np.fromstring(z, np.uint8)
     mask = cv.imdecode(n, cv.IMREAD_UNCHANGED)[..., 3]
 
-    contours, _ = cv.findContours(mask.astype(np.uint8), cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv.findContours(
+        mask.astype(np.uint8), cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE
+    )
     contours = np.vstack(contours)
     contours += obj["bitmap"]["origin"]
 
@@ -148,10 +150,10 @@ def convert_object_entry_segmentation(
 
 
 def write_meta_data(
-        darknet_export_base: Path,
-        class_id_mapping: dict,
-        num_labeled_images: int,
-        class_counter: dict,
+    darknet_export_base: Path,
+    class_id_mapping: dict,
+    num_labeled_images: int,
+    class_counter: dict,
 ):
     excluded_by_tag = class_counter.pop("excluded_by_tag", 0)
 
@@ -169,7 +171,7 @@ def write_meta_data(
     print("Objects per class:\n")
 
     for class_name, count in sorted(
-            class_counter.items(), key=lambda kv: kv[1], reverse=True
+        class_counter.items(), key=lambda kv: kv[1], reverse=True
     ):
         print(f"{class_name} -> {count}")
 
@@ -186,7 +188,7 @@ def write_meta_data(
         total_num_objects = 0
 
         for class_name, count in sorted(
-                class_counter.items(), key=lambda kv: kv[1], reverse=True
+            class_counter.items(), key=lambda kv: kv[1], reverse=True
         ):
             total_num_objects += count
             class_stat_file.write(f"{class_name} -> {count}\n")
@@ -201,13 +203,13 @@ def write_meta_data(
 
 
 def convert_label(
-        darknet_export_images_dir: Path,
-        darknet_export_labels_dir: Path,
-        class_id_mapping: dict,
-        remove_watermark: bool,
-        segmentation: bool,
-        exclude_tags: list,
-        label: Path,
+    darknet_export_images_dir: Path,
+    darknet_export_labels_dir: Path,
+    class_id_mapping: dict,
+    remove_watermark: bool,
+    segmentation: bool,
+    exclude_tags: list,
+    label: Path,
 ):
     class_counter = defaultdict(int)
     name = label.stem
@@ -250,8 +252,15 @@ def convert_label(
                                 class_counter[class_title] += 1
 
                                 darknet_label.write(
-                                    "{} {}\n".format(class_id, ' '.join(
-                                        [' '.join(map(str, row[0])) for row in list(segmentation_mask)]))
+                                    "{} {}\n".format(
+                                        class_id,
+                                        " ".join(
+                                            [
+                                                " ".join(map(str, row[0]))
+                                                for row in list(segmentation_mask)
+                                            ]
+                                        ),
+                                    )
                                 )
                         else:
                             (
@@ -295,7 +304,11 @@ def convert_label(
 
 
 def main(
-        sly_project_path: str, output_path: str, remove_watermark: bool, segmentation: bool, exclude: list
+    sly_project_path: str,
+    output_path: str,
+    remove_watermark: bool,
+    segmentation: bool,
+    exclude: list,
 ):
     class_id_mapping = fsoco_to_class_id_mapping()
 
@@ -323,7 +336,7 @@ def main(
 
     with Pool() as p:
         for class_counter in tqdm.tqdm(
-                p.imap_unordered(convert_func, labels), total=len(labels)
+            p.imap_unordered(convert_func, labels), total=len(labels)
         ):
             for class_name, count in class_counter.items():
                 global_class_counter[class_name] += count

--- a/tools/label_converters/sly2yolo/sly2yolo.py
+++ b/tools/label_converters/sly2yolo/sly2yolo.py
@@ -11,7 +11,6 @@ from functools import partial
 import zlib
 import base64
 import numpy as np
-import cv2
 
 from ..helpers import fsoco_to_class_id_mapping
 from watermark.watermark import FSOCO_IMPORT_BORDER_THICKNESS
@@ -131,9 +130,9 @@ def convert_object_entry_segmentation(
 
     z = zlib.decompress(base64.b64decode(obj["bitmap"]["data"]))
     n = np.fromstring(z, np.uint8)
-    mask = cv2.imdecode(n, cv2.IMREAD_UNCHANGED)[..., 3]
+    mask = cv.imdecode(n, cv.IMREAD_UNCHANGED)[..., 3]
 
-    contours, _ = cv2.findContours(mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv.findContours(mask.astype(np.uint8), cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
     contours = np.vstack(contours)
     contours += obj["bitmap"]["origin"]
 

--- a/tools/label_converters/sly2yolo/sly2yolo.py
+++ b/tools/label_converters/sly2yolo/sly2yolo.py
@@ -228,7 +228,32 @@ def convert_label(
 
                 for obj in data["objects"]:
                     try:
-                        if not segmentation:
+                        if segmentation:
+                            (
+                                class_id,
+                                class_title,
+                                segmentation_mask,
+                            ) = convert_object_entry_segmentation(
+                                obj,
+                                image_height=image_height,
+                                image_width=image_width,
+                                class_id_mapping=class_id_mapping,
+                                remove_watermark=remove_watermark,
+                                exclude_tags=exclude_tags,
+                            )
+
+                            if class_id is None:
+                                class_counter["excluded_by_tag"] += 1
+                                continue
+
+                            else:
+                                class_counter[class_title] += 1
+
+                                darknet_label.write(
+                                    "{} {}\n".format(class_id, ' '.join(
+                                        [' '.join(map(str, row[0])) for row in list(segmentation_mask)]))
+                                )
+                        else:
                             (
                                 class_id,
                                 class_title,
@@ -260,31 +285,6 @@ def convert_label(
                                         norm_bb_width,
                                         norm_bb_height,
                                     )
-                                )
-                        else:
-                            (
-                                class_id,
-                                class_title,
-                                segmentation_mask,
-                            ) = convert_object_entry_segmentation(
-                                obj,
-                                image_height=image_height,
-                                image_width=image_width,
-                                class_id_mapping=class_id_mapping,
-                                remove_watermark=remove_watermark,
-                                exclude_tags=exclude_tags,
-                            )
-
-                            if class_id is None:
-                                class_counter["excluded_by_tag"] += 1
-                                continue
-
-                            else:
-                                class_counter[class_title] += 1
-
-                                darknet_label.write(
-                                    "{} {}\n".format(class_id, ' '.join(
-                                        [' '.join(map(str, row[0])) for row in list(segmentation_mask)]))
                                 )
                     except RuntimeWarning as e:
                         click.echo(

--- a/tools/label_converters/sly2yolo/sly2yolo.py
+++ b/tools/label_converters/sly2yolo/sly2yolo.py
@@ -124,7 +124,7 @@ def convert_object_entry_segmentation(
     tags = [tag["name"] for tag in obj["tags"]]
 
     if any(tag in tags for tag in exclude_tags):
-        return None, None, None, None, None, None
+        return None, None
 
     class_title = obj["classTitle"]
     class_id = class_id_mapping[class_title]

--- a/tools/label_converters/sly2yolo/sly2yolo.py
+++ b/tools/label_converters/sly2yolo/sly2yolo.py
@@ -135,15 +135,8 @@ def convert_object_entry_segmentation(
         mask = cv2.imdecode(n, cv2.IMREAD_UNCHANGED)[..., 3]
 
         contours, _ = cv2.findContours(mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        contours = np.array(contours)
-        contours = contours[0]
-        try:
-            contours += obj["bitmap"]["origin"]
-        except:
-            print(mask)
-            print(obj["bitmap"]["origin"])
-            print(contours)
-            print(contours.shape)
+        contours = np.vstack(contours)
+        contours += obj["bitmap"]["origin"]
 
         if remove_watermark:
             contours -= FSOCO_IMPORT_BORDER_THICKNESS


### PR DESCRIPTION
Resolves #264 

Use `--segmentation` flag when processing segmentation labeling.

Sample command: `fsoco label-converters sly2yolo --remove_watermark --segmentation <INPUT_FOLDER> <OUTPUT_FOLDER>`